### PR TITLE
Ubuntu/Linux build modifications to allow for a clean build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
 # Project exclude paths
 /cmake-build-debug-wsl/CMakeFiles/
 /cmake-build-release-wsl/CMakeFiles/
+
+# Make Artifacts
+**/_deps
+**/CMakeFiles
+**/Makefile
+**/CTestTestfile.cmake
+**/cmake_install.cmake
+**/CMakeCache.txt
+
+# Build Artifacts
+**/lib
+SystemBenchmark/SystemBenchmark
+SystemLib/libSystemLib.a
+SystemLib/main
+SystemTest/SystemTest

--- a/SystemLib/CMakeLists.txt
+++ b/SystemLib/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(main ${SYSTEM_LIB_SOURCES})
 if(WIN32)
     target_link_libraries(main sfml-system sfml-window sfml-graphics sfml-audio -mwindows -static -static-libstdc++ -static-libgcc)
 else()
-    target_link_libraries(main sfml-system sfml-window sfml-graphics sfml-audio -mwindows -static -static-libstdc++ -static-libgcc -lX11)
+    target_link_libraries(main sfml-system sfml-window sfml-graphics sfml-audio -static-libstdc++ -static-libgcc -lX11)
 endif()
 
 

--- a/SystemLib/main.cpp
+++ b/SystemLib/main.cpp
@@ -115,7 +115,7 @@ int main() {
     });
     window.setActive(false);
     renderThread.launch();
-    Time delayTime = milliseconds(1);
+    sf::Time delayTime = milliseconds(1);
 
     while(running) {
         sleep(delayTime);


### PR DESCRIPTION
Hello @Sterling1111 -- you'll find this PR has two components in two individual commits if you choose to pull one but not both into your emulator. Mainly this is to get the application to build/run in linux without CLion. 

- Updates to the gitignore file to ignore the make/build artifacts
- Updated the build errors I encounter that I imagine anyone building on Linux without CLion would face - the big one is the Time namespace issue.

Overall, I hope you continue improving this project as it's pretty slick, especially if you need a simple emulator for simple programs to run/test for running on Ben Eater's 6502 computer.
